### PR TITLE
[JENKINS-53394] Error control when launching the agent via exceptions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>file-leak-detector</artifactId>
-      <version>1.11</version>
+      <version>1.13</version>
       <classifier>jar-with-dependencies</classifier>
       <exclusions>
         <exclusion>

--- a/src/main/java/com/cloudbees/jenkins/plugins/file_leak_detector/FileHandleDump.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/file_leak_detector/FileHandleDump.java
@@ -81,21 +81,26 @@ public class FileHandleDump extends ManagementLink {
             .add(PosixAPI.jnr().getpid())
             .add(Util.fixEmpty(opts));
 
-        Process p = new ProcessBuilder(args.toCommandArray())
-                .redirectErrorStream(true)
-                .start();
+        Process p = new ProcessBuilder(args.toCommandArray()).start();
 
         p.getOutputStream().close();
 
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        IOUtils.copy(p.getInputStream(),baos);
+        ByteArrayOutputStream baosOut = new ByteArrayOutputStream();
+        ByteArrayOutputStream baosErr = new ByteArrayOutputStream();
+        IOUtils.copy(p.getInputStream(),baosOut);
+        IOUtils.copy(p.getErrorStream(),baosErr);
+
         IOUtils.closeQuietly(p.getInputStream());
         IOUtils.closeQuietly(p.getErrorStream());
 
-        int exitCode = p.waitFor();
+        p.waitFor();
 
-        if (exitCode!=0)
-            throw new Error("Failed to activate file leak detector: "+baos);
+        if(baosErr.size() > 0) {
+            // As the real cause of the failure of the agent is lost and we cannot access it, we can only recommend to
+            // see the logs.
+            throw new Error("Failed to activate file leak detector.\nPerhaps wrong parameters.\n" +
+                    "See logs for more info.\nSpecifically, look for 'Agent failed to start!' or something related\n\n");
+        }
 
         return HttpResponses.plainText("Successfully activated file leak detector");
     }

--- a/src/main/java/com/cloudbees/jenkins/plugins/file_leak_detector/FileHandleDump.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/file_leak_detector/FileHandleDump.java
@@ -81,26 +81,24 @@ public class FileHandleDump extends ManagementLink {
             .add(PosixAPI.jnr().getpid())
             .add(Util.fixEmpty(opts));
 
-        Process p = new ProcessBuilder(args.toCommandArray()).start();
+        Process p = new ProcessBuilder(args.toCommandArray())
+                .redirectErrorStream(true)
+                .start();
 
         p.getOutputStream().close();
 
-        ByteArrayOutputStream baosOut = new ByteArrayOutputStream();
-        ByteArrayOutputStream baosErr = new ByteArrayOutputStream();
-        IOUtils.copy(p.getInputStream(),baosOut);
-        IOUtils.copy(p.getErrorStream(),baosErr);
-
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        IOUtils.copy(p.getInputStream(),baos);
         IOUtils.closeQuietly(p.getInputStream());
         IOUtils.closeQuietly(p.getErrorStream());
 
-        p.waitFor();
+        int exitCode = p.waitFor();
 
-        if(baosErr.size() > 0) {
+        if (exitCode!=0)
             // As the real cause of the failure of the agent is lost and we cannot access it, we can only recommend to
             // see the logs.
             throw new Error("Failed to activate file leak detector.\nPerhaps wrong parameters.\n" +
                     "See logs for more info.\nSpecifically, look for 'Agent failed to start!' or something related\n\n");
-        }
 
         return HttpResponses.plainText("Successfully activated file leak detector");
     }


### PR DESCRIPTION
See [[JENKINS-53394] A invalid property set on the configuration from the UI of file-leak-detector kills the Jenkins instance](https://issues.jenkins.io/browse/JENKINS-53394)

This PR is complementary and blocked by https://github.com/kohsuke/file-leak-detector/pull/41 and https://github.com/kohsuke/file-leak-detector/pull/43

Please **don't merge as is**. Before merging , we have to change the _dependency_  to **file-leak-detector** in the **pom.xml** to use the version released by the referred PR.