### PR TITLE
Include process output in error message

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/file_leak_detector/FileHandleDump.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/file_leak_detector/FileHandleDump.java
@@ -114,7 +114,7 @@ public class FileHandleDump extends ManagementLink {
             ServletException, and the message is duplicated, which is confusing when we have such a large message like this.
             */
             Exception e = new Failure("Failed to activate file leak detector. Perhaps the parameters were incorrect. " +
-                    "Look for 'Agent failed to start!' in stderr logs for more info. Additional logs:\n"+baos.toString(), true);
+                    "Look for 'Agent failed to start!' in stderr logs for more info. Additional logs:\n"+baos, true);
             // Print the messsage to the logs so we have a timestamp and the error message in case we need it later.
             // If we use a different exception type, this happens automatically, but we use Failure for reasons described above.
             LOGGER.log(Level.WARNING, e.getMessage());


### PR DESCRIPTION
The change to the log line in #5 to remove `baos` from the output makes sense in some cases, but in other cases it makes it impossible to diagnose errors, so I've added it back with a clarifying comment. In short, if file-leak-detector fails in `AgentMain` due to an invalid option or other issue in the agent, then yes, the output of the process here will not be helpful to understand the root cause, but if file-leak-detector fails in `Main` (maybe because a JRE is being used instead of a JDK), then the output of the process will contain the root cause, and nothing will be printed to Jenkins' stderr when the failure occurs.  

Because of this, we need to include `baos` in the output or we will be unable to diagnose failures in the second case. Failures in the agent (case one) are the most common, but I ran into the second case trying to use the plugin to investigate an instance running on Alpine Linux.