### PR TITLE
Demonstrate adding findsecbugs to spotbugs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 work
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.7</version>
+    <version>3.51</version>
   </parent>
 
   <groupId>com.cloudbees.jenkins.plugins</groupId>
@@ -16,8 +16,11 @@
   <url>https://wiki.jenkins.io/display/JENKINS/File+Leak+Detector+Plugin</url>
 
   <properties>
-        <jenkins.version>2.7.3</jenkins.version>
-        <java.level>8</java.level>
+    <jenkins.version>2.7.3</jenkins.version>
+    <java.level>8</java.level>
+    <spotbugs.effort>Max</spotbugs.effort>
+    <spotbugs.failOnError>true</spotbugs.failOnError>
+    <spotbugs.threshold>Low</spotbugs.threshold>
   </properties>
 
   <dependencies>
@@ -59,5 +62,24 @@
             <url>http://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
-</project>  
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <configuration>
+          <plugins>
+            <plugin>
+              <groupId>com.h3xstream.findsecbugs</groupId>
+              <artifactId>findsecbugs-plugin</artifactId>
+              <version>1.10.1</version>
+            </plugin>
+          </plugins>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/file_leak_detector/FileHandleDump.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/file_leak_detector/FileHandleDump.java
@@ -1,5 +1,6 @@
 package com.cloudbees.jenkins.plugins.file_leak_detector;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.Hudson;
@@ -64,6 +65,7 @@ public class FileHandleDump extends ManagementLink {
      * Activates the file leak detector.
      */
     @RequirePOST
+    @SuppressFBWarnings(value = "COMMAND_INJECTION", justification = "Requires ADMINISTER permission.")
     public HttpResponse doActivate(@QueryParameter String opts) throws Exception {
         Hudson.getInstance().checkPermission(Hudson.ADMINISTER);
 


### PR DESCRIPTION
Demonstrate adding findsecbugs to spotbugs. This commit is a demonstration and is not intended to be merged as-is.

With no changes, findsecbugs reports one finding for this plugin. A quick examination shows that this is used during configuration of this plugin and requires Administer privileges. Under different circumstances this could be an important finding, but in this case, we can suppress it.

---

My plan is to add findsecbugs at the plugin pom after sufficient testing and communication. At that point, it would make sense to add the suppression, but not the pom file changes from this PR.