### PR TITLE
Use `jnr-posix-api` plugin

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.2</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+## Changelog
+
+### Version 1.6 (November 2, 2018)
+
+[JENKINS-53394](https://issues.jenkins.io/browse/JENKINS-53394): Avoid killing Jenkins when the arguments are wrong
+
+### Version 1.5 (April 16, 2018)
+
+Add support for detecting file descriptors used by the following resources:
+
+- Files opened via `java.nio.channels.FileChannel#open`
+- Selectors opened via `java.nio.channels.Selector#open`
+- Pipes opened via `java.nio.channels.Pipe#open`(Unix only)
+
+### Version 1.4 (June 08, 2015)
+
+Metadata fixed
+
+### Version 1.3 (September 11, 2013)
+
+?
+
+### Version 1.2 (April 3, 2012)
+
+Improved compatibility with the monitoring plugin by forking a separate JVM to do the attachment
+
+### Version 1.1 (April 3, 2012)
+
+First public release

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# CloudBees File Leak Detector
+
+## Introduction
+
+Runtime diagnosis tool for "too many open files" problem.
+This plugin watches file descriptor open/close activities of JVM and allow you to see the list of what's currently opened, and Java call stack that opened the file.
+If you are suffering from the too many open files problem, this report enables the developers to fix the leak.
+
+## Usage
+
+This plugin adds "Open File Handles" item in the "Manage Jenkins" page.
+Go to this page and click "activate" button to activate the monitoring.
+Once this is done, a Java agent is installed on the JVM and starts monitoring new file open/close activities.
+Revisit the "Open File Handles" page and you'll see the currently opened files.
+
+To help the developers, activate this, and let Jenkins run for a while, then come back and capture the report and attach it to a ticket.
+Do get a few reports with intervals of 10 mins or so, so that we can distinguish real leaks from false positives.

--- a/pom.xml
+++ b/pom.xml
@@ -1,26 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.7</version>
+    <version>4.31</version>
+    <relativePath />
   </parent>
 
   <groupId>com.cloudbees.jenkins.plugins</groupId>
   <artifactId>file-leak-detector</artifactId>
   <name>CloudBees File Leak Detector Plugin</name>
   <description>Monitors and detects file handle leaks in Jenkins</description>
-  <version>1.7-SNAPSHOT</version>
+  <version>${revision}${changelist}</version>
   <packaging>hpi</packaging>
-  <url>https://wiki.jenkins.io/display/JENKINS/File+Leak+Detector+Plugin</url>
+  <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
 
   <properties>
-        <jenkins.version>2.7.3</jenkins.version>
-        <java.level>8</java.level>
+    <revision>1.7</revision>
+    <changelist>-SNAPSHOT</changelist>
+    <jenkins.version>2.303.3</jenkins.version>
+    <java.level>8</java.level>
+    <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.303.x</artifactId>
+        <version>1013.vf8058992a042</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>jnr-posix-api</artifactId>
+      <version>3.1.7-1</version>
+    </dependency>
     <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>file-leak-detector</artifactId>
@@ -40,10 +62,10 @@
   </dependencies>
 
   <scm>
-    <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
-    <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
-    <tag>HEAD</tag>
+    <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
+    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+    <url>https://github.com/${gitHubRepo}</url>
+    <tag>${scmTag}</tag>
   </scm>
 
   <repositories>


### PR DESCRIPTION
This PR switches this plugin to depend on the newly-released [`jnr-posix-api`](https://plugins.jenkins.io/jnr-posix-api/) plugin rather than getting JNR from core. Once this is merged and released, and once enough users have upgraded to this release, we can consider removing the JNR dependency from core.

CC @jglick @dwnusbaum