### PR TITLE
[JENKINS-52308] Support for Java 11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,6 @@
 // Build the plugin using https://github.com/jenkins-infra/pipeline-library
-buildPlugin()
+buildPlugin(useContainerAgent: true, configurations: [
+  [ platform: 'linux', jdk: '8' ],
+  [ platform: 'linux', jdk: '11' ],
+  [ platform: 'windows', jdk: '11' ]
+])

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>file-leak-detector</artifactId>
-      <version>1.13</version>
+      <version>1.14</version>
       <classifier>jar-with-dependencies</classifier>
       <exclusions>
         <exclusion>
@@ -54,8 +54,24 @@
           <artifactId>args4j</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.kohsuke</groupId>
-          <artifactId>asm6</artifactId>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>asm</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>asm-analysis</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>asm-commons</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>asm-tree</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>asm-util</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
### Background

See [JENKINS-52308](https://issues.jenkins.io/browse/JENKINS-52308).

### Problem

This repository uses an old version of [File Leak Detector](https://github.com/jenkinsci/lib-file-leak-detector) without support for Java 11.

### Solution

Upgrade to [1.14](https://github.com/jenkinsci/lib-file-leak-detector/releases/tag/file-leak-detector-1.14), which adds support for Java 11.

### Implementation

We bundle the `jar-with-dependencies` version, which shades args4j and ASM, so we do not want to bundle args4j and ASM in the JPI file. Therefore, we exclude these dependencies.

### Testing done

- Ran `mvn clean verify` on both Java 8 and Java 11.
- Ran `mvn clean package` on Java 8, then installed the JPI on a local Jenkins controller running on Java 11. Went to the UI and successfully activated the File Leak Detector and saw entries appearing in the table.

### Bonus

Also upgrades Release Drafter, `git-changelist-maven-extension`, the plugin parent POM, the plugin BOM, and `jnr-posix-api` to the latest versions.